### PR TITLE
Only provide SRV records when at least 3 exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ accessible through a standard DNS server.
 ## Syntax
 
 ~~~
-mdns example.com
+mdns example.com [minimum SRV records]
 ~~~
 
 ## Examples
@@ -40,3 +40,17 @@ dig @localhost baremetal-test-extra-1.example.com
 baremetal-test-extra-1.example.com. 60 IN A   12.0.0.24
 baremetal-test-extra-1.example.com. 60 IN AAAA fe80::f816:3eff:fe49:19b3
 ~~~
+
+If `minimum SRV records` is specified in the configuration, the plugin will wait
+until it has at least that many SRV records before responding with any of them.
+`minimum SRV records` defaults to `3`.
+
+~~~ corefile
+example.com {
+    mdns example.com 2
+}
+~~~
+
+This would mean that at least two SRV records of a given type would need to be
+present for any SRV records to be returned. If only one record is found, any
+requests for that type of SRV record would receive no results.

--- a/mdns.go
+++ b/mdns.go
@@ -172,7 +172,10 @@ func (m *MDNS) BrowseMDNS() {
 		(*m.mdnsHosts)[k] = v
 	}
 	for k, v := range srvHosts {
-		(*m.srvHosts)[k] = v
+		// Hax!
+		if len(v) >= 3 {
+			(*m.srvHosts)[k] = v
+		}
 	}
 	for k, v := range cnames {
 		(*m.cnames)[k] = v

--- a/mdns.go
+++ b/mdns.go
@@ -21,6 +21,7 @@ var log = clog.NewWithPlugin("mdns")
 type MDNS struct {
 	Next      plugin.Handler
 	Domain    string
+	minSRV    int
 	mutex     *sync.RWMutex
 	mdnsHosts *map[string]*mdns.ServiceEntry
 	srvHosts  *map[string][]*mdns.ServiceEntry
@@ -172,8 +173,9 @@ func (m *MDNS) BrowseMDNS() {
 		(*m.mdnsHosts)[k] = v
 	}
 	for k, v := range srvHosts {
-		// Hax!
-		if len(v) >= 3 {
+		// Don't return any SRV records until we have enough of them. Returning
+		// partial SRV lists can result in bad clustering.
+		if len(v) >= m.minSRV {
 			(*m.srvHosts)[k] = v
 		}
 	}


### PR DESCRIPTION
If we provide partial SRV record lists it is possible for etcd to
come up in a partial cluster that breaks us. By waiting until all
three are available we can avoid this situation.