### PR TITLE
Add ability to filter mdns records by name

### DIFF
--- a/mdns.go
+++ b/mdns.go
@@ -197,6 +197,11 @@ func (m *MDNS) BrowseMDNS() {
 	}
 	log.Debugf("mdnsHosts: %v", m.mdnsHosts)
 	log.Debugf("srvHosts: %v", m.srvHosts)
+	for name, records := range (*m.srvHosts) {
+		for _, v := range records {
+			log.Debugf("%s: %s", name, v)
+		}
+	}
 	log.Debugf("cnames: %v", m.cnames)
 }
 

--- a/setup.go
+++ b/setup.go
@@ -28,6 +28,8 @@ func setup(c *caddy.Controller) error {
 	c.NextArg()
 	domain := c.Val()
 	minSRV := 3
+	// Note that a filter of "" will match everything
+	filter := ""
 	if c.NextArg() {
 		val, err := strconv.Atoi(c.Val())
 		if err != nil {
@@ -35,6 +37,9 @@ func setup(c *caddy.Controller) error {
 			return plugin.Error("mdns", errors.New(text))
 		}
 		minSRV = val
+	}
+	if c.NextArg() {
+		filter = c.Val()
 	}
 	if c.NextArg() {
 		return plugin.Error("mdns", c.ArgErr())
@@ -46,7 +51,7 @@ func setup(c *caddy.Controller) error {
 	srvHosts := make(map[string][]*mdns.ServiceEntry)
 	cnames := make(map[string]string)
 	mutex := sync.RWMutex{}
-	m := MDNS{Domain: strings.TrimSuffix(domain, "."), minSRV: minSRV, mutex: &mutex, mdnsHosts: &mdnsHosts, srvHosts: &srvHosts, cnames: &cnames}
+	m := MDNS{Domain: strings.TrimSuffix(domain, "."), minSRV: minSRV, filter: filter, mutex: &mutex, mdnsHosts: &mdnsHosts, srvHosts: &srvHosts, cnames: &cnames}
 
 	c.OnStartup(func() error {
 		// mdns is quite noisy, and we don't really care about any of its messages


### PR DESCRIPTION
Adds another configuration value to the plugin that can be used to
filter the records received from mdns-publisher. This allows us to
include the cluster name in the service names and avoid reading
records from any other mdns services that may be running on the same
network.

The filter uses a simple substring match, so the value used should
be as unique as possible to avoid accidental matches.